### PR TITLE
feat: Expand Laravel and PHP version support for broader compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Transform your Laravel applications into beautiful, fast, and secure cross-platf
 
 Before using Tauri-PHP, ensure you have the following installed:
 
-- **PHP 8.1 or higher**
-- **Laravel 10.x or 11.x**
+- **PHP 8.0 or higher** (8.0, 8.1, 8.2, or 8.3)
+- **Laravel 9.x, 10.x, or 11.x**
 - **Node.js 18+** and npm
 - **Rust and Cargo** - Install from [rustup.rs](https://rustup.rs/)
 - **Docker** (optional, for cross-platform builds)

--- a/composer.json
+++ b/composer.json
@@ -22,17 +22,17 @@
     }
   ],
   "require": {
-    "php": "^8.1|^8.2|^8.3",
-    "illuminate/support": "^10.0|^11.0",
-    "illuminate/console": "^10.0|^11.0",
-    "symfony/process": "^6.0|^7.0",
-    "symfony/filesystem": "^6.0|^7.0"
+    "php": "^8.0|^8.1|^8.2|^8.3",
+    "illuminate/support": "^9.0|^10.0|^11.0",
+    "illuminate/console": "^9.0|^10.0|^11.0",
+    "symfony/process": "^5.4|^6.0|^7.0",
+    "symfony/filesystem": "^5.4|^6.0|^7.0"
   },
   "require-dev": {
-    "laravel/pint": "^1.25",
-    "mockery/mockery": "^1.6",
-    "orchestra/testbench": "^8.0|^9.0",
-    "phpunit/phpunit": "^10.0"
+    "laravel/pint": "^1.0",
+    "mockery/mockery": "^1.5",
+    "orchestra/testbench": "^7.0|^8.0|^9.0",
+    "phpunit/phpunit": "^9.5|^10.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
- Add support for Laravel 9.x (previously only 10.x and 11.x)
- Add support for PHP 8.0 (previously only 8.1+)
- Expand Symfony dependencies to include 5.4 LTS versions
- Update dev dependencies for Laravel 9.x compatibility
- Update README prerequisites to reflect expanded support

This resolves installation conflicts for Laravel 9.x users where illuminate/support ^10.0|^11.0 was causing composer resolution errors.