### PR TITLE
feat: Add Laravel 12.x support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Transform your Laravel applications into beautiful, fast, and secure cross-platf
 Before using Tauri-PHP, ensure you have the following installed:
 
 - **PHP 8.0 or higher** (8.0, 8.1, 8.2, or 8.3)
-- **Laravel 9.x, 10.x, or 11.x**
+- **Laravel 9.x, 10.x, 11.x, or 12.x**
 - **Node.js 18+** and npm
 - **Rust and Cargo** - Install from [rustup.rs](https://rustup.rs/)
 - **Docker** (optional, for cross-platform builds)

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "mucan54/tauri-php",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Build cross-platform desktop applications with Laravel and Tauri. Embed your Laravel app into native desktop apps for Windows, macOS, and Linux using FrankenPHP.",
   "keywords": [
     "laravel",
@@ -23,16 +23,16 @@
   ],
   "require": {
     "php": "^8.0|^8.1|^8.2|^8.3",
-    "illuminate/support": "^9.0|^10.0|^11.0",
-    "illuminate/console": "^9.0|^10.0|^11.0",
+    "illuminate/support": "^9.0|^10.0|^11.0|^12.0",
+    "illuminate/console": "^9.0|^10.0|^11.0|^12.0",
     "symfony/process": "^5.4|^6.0|^7.0",
     "symfony/filesystem": "^5.4|^6.0|^7.0"
   },
   "require-dev": {
     "laravel/pint": "^1.0",
     "mockery/mockery": "^1.5",
-    "orchestra/testbench": "^7.0|^8.0|^9.0",
-    "phpunit/phpunit": "^9.5|^10.0"
+    "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
+    "phpunit/phpunit": "^9.5|^10.0|^11.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
- Add support for Laravel 12.x (illuminate/support and illuminate/console)
- Update Orchestra Testbench to support Laravel 12 (^10.0)
- Update PHPUnit to support version 11
- Update README prerequisites to include Laravel 12.x
- Bump version to 1.2.0

This resolves installation conflicts for Laravel 12.x users where illuminate/support ^9.0|^10.0|^11.0 was preventing package installation.