### PR TITLE
fix: Remove duplicate --verbose option from all commands

### DIFF
--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -27,8 +27,7 @@ class BuildCommand extends Command
                             {--skip-deps : Skip installing dependencies}
                             {--force : Force rebuild of FrankenPHP binaries}
                             {--apk : Build APK for Android (default is AAB)}
-                            {--open : Open in Xcode after build (iOS only)}
-                            {--verbose : Show detailed output}';
+                            {--open : Open in Xcode after build (iOS only)}';
 
     /**
      * The console command description.

--- a/src/Console/DevCommand.php
+++ b/src/Console/DevCommand.php
@@ -20,8 +20,7 @@ class DevCommand extends Command
      */
     protected $signature = 'tauri:dev
                             {--host=127.0.0.1 : Development server host}
-                            {--port=8080 : Development server port}
-                            {--verbose : Show detailed output}';
+                            {--port=8080 : Development server port}';
 
     /**
      * The console command description.

--- a/src/Console/InitCommand.php
+++ b/src/Console/InitCommand.php
@@ -23,8 +23,7 @@ class InitCommand extends Command
                             {--identifier= : Application identifier (com.company.app)}
                             {--php-version=8.3 : PHP version}
                             {--extensions= : PHP extensions (comma-separated)}
-                            {--force : Overwrite existing files}
-                            {--verbose : Show detailed output}';
+                            {--force : Overwrite existing files}';
 
     /**
      * The console command description.

--- a/src/Console/MobileDevCommand.php
+++ b/src/Console/MobileDevCommand.php
@@ -21,8 +21,7 @@ class MobileDevCommand extends Command
                             {--device= : Specific device to run on}
                             {--emulator : Run on emulator/simulator instead of physical device}
                             {--host=0.0.0.0 : Development server host (0.0.0.0 for mobile access)}
-                            {--port=8080 : Development server port}
-                            {--verbose : Show detailed output}';
+                            {--port=8080 : Development server port}';
 
     /**
      * The console command description.

--- a/src/Console/MobileInitCommand.php
+++ b/src/Console/MobileInitCommand.php
@@ -19,8 +19,7 @@ class MobileInitCommand extends Command
     protected $signature = 'tauri:mobile-init
                             {platform : Mobile platform (android|ios|both)}
                             {--package-name= : Android package name or iOS bundle identifier}
-                            {--team-id= : iOS team ID (required for iOS)}
-                            {--verbose : Show detailed output}';
+                            {--team-id= : iOS team ID (required for iOS)}';
 
     /**
      * The console command description.

--- a/src/Console/PackageCommand.php
+++ b/src/Console/PackageCommand.php
@@ -19,8 +19,7 @@ class PackageCommand extends Command
     protected $signature = 'tauri:package
                             {--format=all : Package format (dmg|app|msi|nsis|deb|appimage|all)}
                             {--sign : Sign the package}
-                            {--output= : Output directory}
-                            {--verbose : Show detailed output}';
+                            {--output= : Output directory}';
 
     /**
      * The console command description.


### PR DESCRIPTION
Laravel's base Command class already provides the --verbose option, so defining it in command signatures causes a conflict error: "An option named 'verbose' already exists."

This fix removes the --verbose option from all command signatures:
- InitCommand
- BuildCommand
- DevCommand
- PackageCommand
- MobileInitCommand
- MobileDevCommand

The --verbose option is still available through Laravel's built-in functionality and can be used as: php artisan tauri:init --verbose