### PR TITLE
fix: Enable LIBXML support in PHP iOS build configuration

### DIFF
--- a/scripts/build-php-ios.sh
+++ b/scripts/build-php-ios.sh
@@ -150,6 +150,7 @@ build_php() {
         --enable-static \
         --disable-shared \
         --disable-all \
+        --enable-libxml \
         --enable-mysqlnd \
         --enable-pdo \
         --with-pdo-mysql=mysqlnd \


### PR DESCRIPTION
The build was failing with:
  configure: error: DOM extension requires LIBXML extension, add --with-libxml

Added --enable-libxml to the configure options to fix the dependency issue. All XML-related extensions (xml, simplexml, dom) require LIBXML to be enabled.

This fixes the automatic build when running:
  php artisan tauri:mobile-dev ios --device "iPhone 15"