### PR TITLE
fix: Use correct --with-libxml configure option for PHP build

### DIFF
--- a/scripts/build-php-ios.sh
+++ b/scripts/build-php-ios.sh
@@ -150,7 +150,7 @@ build_php() {
         --enable-static \
         --disable-shared \
         --disable-all \
-        --enable-libxml \
+        --with-libxml \
         --enable-mysqlnd \
         --enable-pdo \
         --with-pdo-mysql=mysqlnd \
@@ -166,7 +166,6 @@ build_php() {
         --enable-dom \
         --with-openssl \
         --with-zlib \
-        --enable-json \
         --enable-posix \
         --enable-sockets \
         --disable-opcache \


### PR DESCRIPTION
Changed from --enable-libxml to --with-libxml as per PHP configure requirements. Also removed --enable-json which is unrecognized (JSON is enabled by default in PHP 8.x).

The error was:
  configure: WARNING: unrecognized options: --enable-libxml, --enable-json
  configure: error: DOM extension requires LIBXML extension, add --with-libxml

This should now allow the build to proceed successfully.