### PR TITLE
fix: Disable sockets extension for iOS build

### DIFF
--- a/scripts/build-php-ios.sh
+++ b/scripts/build-php-ios.sh
@@ -167,7 +167,6 @@ build_php() {
         --with-openssl \
         --with-zlib \
         --enable-posix \
-        --enable-sockets \
         --disable-opcache \
         --disable-phpdbg \
         --without-pcre-jit \


### PR DESCRIPTION
The sockets extension fails to compile on iOS because it uses system calls that are not available on iOS (SIOCGIFNAME, if_indextoname, SIOCGIFINDEX).

Error encountered:
  ext/sockets/multicast.c:731:2: error: Neither SIOCGIFNAME nor if_indextoname are available

iOS restricts low-level socket multicast operations. Laravel doesn't require the sockets extension for core functionality, so we disable it for iOS builds.

This allows the PHP compilation to complete successfully on iOS.