### PR TITLE
fix: Disable fibers for iOS build due to assembly incompatibility

### DIFF
--- a/scripts/build-php-ios.sh
+++ b/scripts/build-php-ios.sh
@@ -167,6 +167,7 @@ build_php() {
         --with-openssl \
         --with-zlib \
         --enable-posix \
+        --disable-fiber \
         --disable-opcache \
         --disable-phpdbg \
         --without-pcre-jit \


### PR DESCRIPTION
The fiber support in PHP uses ARM64 assembly files with GAS/ELF directives that are incompatible with iOS/Mach-O assembler.

Errors encountered:
  .type make_fcontext, %function  # ELF directive, not supported on Mach-O
  .size make_fcontext,.-make_fcontext  # ELF directive
  .section .note.GNU-stack,"",% progbits  # ELF directive

iOS uses Apple's assembler which expects Mach-O format, not ELF. The assembly files would need to be rewritten for Mach-O to work on iOS.

Since Laravel doesn't require fiber support for normal operation, we disable it with --disable-fiber to allow the build to complete successfully.