### PR TITLE
fix: Use --disable-fiber-asm configure flag for iOS compatibility

### DIFF
--- a/scripts/build-php-ios.sh
+++ b/scripts/build-php-ios.sh
@@ -150,6 +150,7 @@ build_php() {
         --enable-static \
         --disable-shared \
         --disable-all \
+        --disable-fiber-asm \
         --with-libxml \
         --enable-mysqlnd \
         --enable-pdo \
@@ -167,7 +168,6 @@ build_php() {
         --with-openssl \
         --with-zlib \
         --enable-posix \
-        --disable-fiber \
         --disable-opcache \
         --disable-phpdbg \
         --without-pcre-jit \


### PR DESCRIPTION
The correct way to disable fiber assembly in PHP is to use the --disable-fiber-asm configure flag, not an environment variable.

This flag tells PHP to use ucontext implementation instead of boost assembly files, avoiding ELF directive errors on iOS/Mach-O.

The fiber assembly files use ELF-specific directives (.type, .size, .section .note.GNU-stack) that are incompatible with iOS's Mach-O assembler. Using --disable-fiber-asm forces the portable ucontext implementation which works across all platforms.

Refs: https://github.com/php/php-src/blob/master/configure.ac