### PR TITLE
fix: Force ucontext fiber implementation via CPPFLAGS for iOS

### DIFF
--- a/scripts/build-php-ios.sh
+++ b/scripts/build-php-ios.sh
@@ -73,8 +73,9 @@ setup_ios_env() {
     export PLATFORM=$PLATFORM
 
     # Compiler flags
-    export CFLAGS="-arch $ARCH -isysroot $SDK_PATH -miphoneos-version-min=$IOS_MIN_VERSION -fembed-bitcode"
-    export CXXFLAGS="-arch $ARCH -isysroot $SDK_PATH -miphoneos-version-min=$IOS_MIN_VERSION -fembed-bitcode"
+    # Force ucontext-based fiber implementation (not assembly) for iOS compatibility
+    export CFLAGS="-arch $ARCH -isysroot $SDK_PATH -miphoneos-version-min=$IOS_MIN_VERSION -fembed-bitcode -DZEND_FIBER_UCONTEXT"
+    export CXXFLAGS="-arch $ARCH -isysroot $SDK_PATH -miphoneos-version-min=$IOS_MIN_VERSION -fembed-bitcode -DZEND_FIBER_UCONTEXT"
     export LDFLAGS="-arch $ARCH -isysroot $SDK_PATH -miphoneos-version-min=$IOS_MIN_VERSION"
 
     # Toolchain
@@ -150,7 +151,6 @@ build_php() {
         --enable-static \
         --disable-shared \
         --disable-all \
-        --disable-fiber-asm \
         --with-libxml \
         --enable-mysqlnd \
         --enable-pdo \


### PR DESCRIPTION
Instead of using --disable-fiber-asm (which shows as unrecognized), directly define ZEND_FIBER_UCONTEXT preprocessor macro in CFLAGS.

This forces PHP to use the portable ucontext-based fiber implementation instead of assembly-based boost.context, avoiding ELF assembly directive errors on iOS's Mach-O assembler.

The ZEND_FIBER_UCONTEXT macro is checked in zend_fibers.c to determine which implementation to compile.