### PR TITLE
fix: Remove fiber assembly files before build to prevent ELF compilation

### DIFF
--- a/scripts/build-php-ios.sh
+++ b/scripts/build-php-ios.sh
@@ -138,6 +138,13 @@ build_php() {
 
     cd "${BUILD_PHP_DIR}/php-src"
 
+    # Remove fiber assembly files (ELF format incompatible with iOS Mach-O)
+    # We use ucontext implementation instead via ZEND_FIBER_UCONTEXT
+    if [ -d "Zend/asm" ]; then
+        log_info "Removing incompatible fiber assembly files..."
+        rm -rf Zend/asm/*.S
+    fi
+
     # Clean previous builds
     make clean 2>/dev/null || true
 


### PR DESCRIPTION
PHP's configure script still adds assembly files to Makefile even when ZEND_FIBER_UCONTEXT is defined. To prevent compilation errors, we now delete the assembly files (*.S) after copying source but before configure.

This combined with ZEND_FIBER_UCONTEXT forces PHP to use only the portable ucontext-based fiber implementation, avoiding iOS Mach-O assembler incompatibility with ELF directives.