### PR TITLE
fix: Remove entire asm directory to prevent Makefile references

### DIFF
--- a/scripts/build-php-ios.sh
+++ b/scripts/build-php-ios.sh
@@ -138,11 +138,11 @@ build_php() {
 
     cd "${BUILD_PHP_DIR}/php-src"
 
-    # Remove fiber assembly files (ELF format incompatible with iOS Mach-O)
+    # Remove entire fiber assembly directory (ELF format incompatible with iOS Mach-O)
     # We use ucontext implementation instead via ZEND_FIBER_UCONTEXT
     if [ -d "Zend/asm" ]; then
-        log_info "Removing incompatible fiber assembly files..."
-        rm -rf Zend/asm/*.S
+        log_info "Removing incompatible fiber assembly directory..."
+        rm -rf Zend/asm
     fi
 
     # Clean previous builds


### PR DESCRIPTION
The Makefile generated by configure still referenced assembly files even though we deleted them, causing build errors.

By removing the entire Zend/asm directory before buildconf/configure, PHP's build system won't detect or try to use assembly files at all, forcing it to use the ucontext implementation.