### PR TITLE
fix: Define _XOPEN_SOURCE for iOS ucontext.h compilation

### DIFF
--- a/scripts/build-php-ios.sh
+++ b/scripts/build-php-ios.sh
@@ -74,8 +74,9 @@ setup_ios_env() {
 
     # Compiler flags
     # Force ucontext-based fiber implementation (not assembly) for iOS compatibility
-    export CFLAGS="-arch $ARCH -isysroot $SDK_PATH -miphoneos-version-min=$IOS_MIN_VERSION -fembed-bitcode -DZEND_FIBER_UCONTEXT"
-    export CXXFLAGS="-arch $ARCH -isysroot $SDK_PATH -miphoneos-version-min=$IOS_MIN_VERSION -fembed-bitcode -DZEND_FIBER_UCONTEXT"
+    # _XOPEN_SOURCE required by iOS SDK's ucontext.h to expose deprecated ucontext functions
+    export CFLAGS="-arch $ARCH -isysroot $SDK_PATH -miphoneos-version-min=$IOS_MIN_VERSION -fembed-bitcode -DZEND_FIBER_UCONTEXT -D_XOPEN_SOURCE=1"
+    export CXXFLAGS="-arch $ARCH -isysroot $SDK_PATH -miphoneos-version-min=$IOS_MIN_VERSION -fembed-bitcode -DZEND_FIBER_UCONTEXT -D_XOPEN_SOURCE=1"
     export LDFLAGS="-arch $ARCH -isysroot $SDK_PATH -miphoneos-version-min=$IOS_MIN_VERSION"
 
     # Toolchain


### PR DESCRIPTION
iOS SDK's ucontext.h requires _XOPEN_SOURCE to be defined before including the header, otherwise it throws a preprocessor error:

  error: The deprecated ucontext routines require _XOPEN_SOURCE to be defined

This adds -D_XOPEN_SOURCE=1 to CFLAGS and CXXFLAGS to make the deprecated ucontext functions (getcontext, makecontext, swapcontext) visible during compilation of zend_fibers.c.

Note: While these functions are deprecated and stubbed on iOS, we need them to be declared for compilation. Runtime behavior will be tested.