### PR TITLE
fix: Disable OpenSSL and mbregex to avoid macOS library linking

### DIFF
--- a/scripts/build-php-ios.sh
+++ b/scripts/build-php-ios.sh
@@ -170,6 +170,7 @@ build_php() {
         --with-pdo-sqlite \
         --with-sqlite3 \
         --enable-mbstring \
+        --disable-mbregex \
         --enable-bcmath \
         --enable-ctype \
         --enable-fileinfo \
@@ -177,7 +178,7 @@ build_php() {
         --enable-xml \
         --enable-simplexml \
         --enable-dom \
-        --with-openssl \
+        --without-openssl \
         --with-zlib \
         --enable-posix \
         --disable-opcache \


### PR DESCRIPTION
The linker was failing because configure found Homebrew libraries built for macOS instead of iOS:
- OpenSSL from /opt/homebrew/Cellar/openssl@3 (macOS dylib)
- Oniguruma from Homebrew (pulled in by mbstring regex support)

These macOS libraries cannot be linked when building for iOS target.

Temporary solution:
- Disable OpenSSL (--without-openssl instead of --with-openssl)
- Disable mbstring regex support (--disable-mbregex)

This allows basic PHP build to complete. OpenSSL and mbregex can be re-enabled later by building iOS-compatible static libraries for:
- OpenSSL (using openssl-ios or similar)
- Oniguruma (cross-compiled for iOS)

Most Laravel functionality will work without SSL (database, routing, views, etc.), though HTTPS requests and encryption will be limited.