### PR TITLE
fix: Add _DARWIN_C_SOURCE to expose BSD resolver API alongside POSIX

### DIFF
--- a/scripts/build-php-ios.sh
+++ b/scripts/build-php-ios.sh
@@ -75,8 +75,9 @@ setup_ios_env() {
     # Compiler flags
     # Force ucontext-based fiber implementation (not assembly) for iOS compatibility
     # _XOPEN_SOURCE required by iOS SDK's ucontext.h to expose deprecated ucontext functions
-    export CFLAGS="-arch $ARCH -isysroot $SDK_PATH -miphoneos-version-min=$IOS_MIN_VERSION -fembed-bitcode -DZEND_FIBER_UCONTEXT -D_XOPEN_SOURCE=1"
-    export CXXFLAGS="-arch $ARCH -isysroot $SDK_PATH -miphoneos-version-min=$IOS_MIN_VERSION -fembed-bitcode -DZEND_FIBER_UCONTEXT -D_XOPEN_SOURCE=1"
+    # _DARWIN_C_SOURCE required to expose BSD resolver API (HEADER, C_IN, etc.) alongside POSIX
+    export CFLAGS="-arch $ARCH -isysroot $SDK_PATH -miphoneos-version-min=$IOS_MIN_VERSION -fembed-bitcode -DZEND_FIBER_UCONTEXT -D_XOPEN_SOURCE=1 -D_DARWIN_C_SOURCE"
+    export CXXFLAGS="-arch $ARCH -isysroot $SDK_PATH -miphoneos-version-min=$IOS_MIN_VERSION -fembed-bitcode -DZEND_FIBER_UCONTEXT -D_XOPEN_SOURCE=1 -D_DARWIN_C_SOURCE"
     export LDFLAGS="-arch $ARCH -isysroot $SDK_PATH -miphoneos-version-min=$IOS_MIN_VERSION"
 
     # Toolchain


### PR DESCRIPTION
When _XOPEN_SOURCE is defined on Darwin/iOS, it hides non-POSIX APIs including the BSD resolver declarations (HEADER, C_IN, GETSHORT, GETLONG) that PHP's ext/standard/dns.c requires.

This caused compilation errors:
- error: unknown type name 'HEADER'
- error: use of undeclared identifier 'C_IN'
- error: call to undeclared function 'GETSHORT'
- error: call to undeclared function 'GETLONG'

Solution: Define _DARWIN_C_SOURCE alongside _XOPEN_SOURCE to expose both POSIX APIs (ucontext) and Darwin-specific APIs (BSD resolver).

This is the standard approach for Darwin when you need both API sets.