### PR TITLE
fix: Add iOS compatibility patches for unsupported functions

### DIFF
--- a/patches/ios/disable-chroot.patch
+++ b/patches/ios/disable-chroot.patch
@@ -1,0 +1,21 @@
+--- a/ext/standard/dir.c
++++ b/ext/standard/dir.c
+@@ -274,6 +274,13 @@ PHP_FUNCTION(chdir)
+ /* {{{ Change root directory */
+ PHP_FUNCTION(chroot)
+ {
++#if defined(__APPLE__) && (TARGET_OS_IOS || TARGET_OS_SIMULATOR)
++	/* chroot() is not available on iOS */
++	php_error_docref(NULL, E_WARNING, "chroot() is not supported on iOS");
++	RETURN_FALSE;
++#else
+ 	char *str;
+ 	size_t str_len;
+ 	int ret;
+@@ -287,6 +294,7 @@ PHP_FUNCTION(chroot)
+ 	}
+
+ 	RETURN_BOOL(ret == 0);
++#endif
+ }
+ /* }}} */

--- a/patches/ios/disable-dns-resolver.patch
+++ b/patches/ios/disable-dns-resolver.patch
@@ -1,0 +1,16 @@
+--- a/ext/standard/dns.c
++++ b/ext/standard/dns.c
+@@ -329,6 +329,13 @@ PHP_FUNCTION(gethostbyname)
+ /* }}} */
+
+ #if HAVE_FULL_DNS_FUNCS
++
++/* iOS does not expose BSD resolver internals (HEADER, C_IN, etc.) even with feature test macros.
++   Stub out these functions to return false/empty on iOS. */
++#if defined(__APPLE__) && (TARGET_OS_IOS || TARGET_OS_SIMULATOR)
++#undef HAVE_FULL_DNS_FUNCS
++#endif
++
+ /* {{{ php_dns_search
+  */
+ static int php_dns_search(res_state handle, const char *dname, int rclass, int type, u_char *answer, int anslen)

--- a/scripts/build-php-ios.sh
+++ b/scripts/build-php-ios.sh
@@ -151,6 +151,20 @@ build_php() {
         rm -rf Zend/asm
     fi
 
+    # Apply iOS compatibility patches
+    log_info "Applying iOS compatibility patches..."
+    PATCH_DIR="${SCRIPT_DIR}/../patches/ios"
+
+    # Patch to disable DNS resolver functions (iOS doesn't expose HEADER, C_IN, etc.)
+    if [ -f "${PATCH_DIR}/disable-dns-resolver.patch" ]; then
+        patch -p1 -N < "${PATCH_DIR}/disable-dns-resolver.patch" || true
+    fi
+
+    # Patch to disable chroot function (not available on iOS)
+    if [ -f "${PATCH_DIR}/disable-chroot.patch" ]; then
+        patch -p1 -N < "${PATCH_DIR}/disable-chroot.patch" || true
+    fi
+
     # Clean previous builds
     make clean 2>/dev/null || true
 


### PR DESCRIPTION
iOS SDK does not expose certain low-level APIs even with feature test macros. This adds patches to handle iOS-specific limitations:

1. **DNS Resolver API** (ext/standard/dns.c):
   - iOS doesn't expose BSD resolver internals (HEADER, C_IN, GETSHORT, etc.)
   - Patch conditionally undefines HAVE_FULL_DNS_FUNCS on iOS
   - DNS lookup functions (checkdnsrr, dns_get_record, etc.) will return false
   - Basic gethostbyname/gethostbyaddr still work (use higher-level APIs)

2. **chroot Function** (ext/standard/dir.c):
   - chroot() is not available on iOS (sandboxing restriction)
   - Patch stubs the function to return false with warning

These patches are applied automatically during build process after copying PHP source but before configure. Using patch -p1 -N to avoid errors if already applied (idempotent).

Impact:
- Most PHP functionality unaffected
- Advanced DNS record querying unavailable on iOS
- chroot() calls will fail (rarely used in typical apps)
- Laravel and most frameworks will work normally