### PR TITLE
fix: Correct patch file format and placement for iOS compatibility

### DIFF
--- a/patches/ios/disable-chroot.patch
+++ b/patches/ios/disable-chroot.patch
@@ -1,6 +1,6 @@
 --- a/ext/standard/dir.c
 +++ b/ext/standard/dir.c
-@@ -274,6 +274,13 @@ PHP_FUNCTION(chdir)
+@@ -274,6 +274,12 @@ PHP_FUNCTION(chdir)
  /* {{{ Change root directory */
  PHP_FUNCTION(chroot)
  {
@@ -12,7 +12,7 @@
  	char *str;
  	size_t str_len;
  	int ret;
-@@ -287,6 +294,7 @@ PHP_FUNCTION(chroot)
+@@ -287,6 +293,7 @@ PHP_FUNCTION(chroot)
  	}
 
  	RETURN_BOOL(ret == 0);

--- a/patches/ios/disable-dns-resolver.patch
+++ b/patches/ios/disable-dns-resolver.patch
@@ -1,16 +1,14 @@
 --- a/ext/standard/dns.c
 +++ b/ext/standard/dns.c
-@@ -329,6 +329,13 @@ PHP_FUNCTION(gethostbyname)
+@@ -329,6 +329,12 @@ PHP_FUNCTION(gethostbyname)
  /* }}} */
 
- #if HAVE_FULL_DNS_FUNCS
-+
 +/* iOS does not expose BSD resolver internals (HEADER, C_IN, etc.) even with feature test macros.
-+   Stub out these functions to return false/empty on iOS. */
++   Disable full DNS functions on iOS to avoid compilation errors. */
 +#if defined(__APPLE__) && (TARGET_OS_IOS || TARGET_OS_SIMULATOR)
 +#undef HAVE_FULL_DNS_FUNCS
 +#endif
 +
+ #if HAVE_FULL_DNS_FUNCS
+
  /* {{{ php_dns_search
-  */
- static int php_dns_search(res_state handle, const char *dname, int rclass, int type, u_char *answer, int anslen)


### PR DESCRIPTION
Fixed two issues with the iOS compatibility patches:

1. **Line number corrections**: Updated hunk line numbers to match actual source file structure in PHP 8.3.14

2. **DNS patch placement**: Moved the HAVE_FULL_DNS_FUNCS undef to BEFORE the #if check (line 329) instead of inside it. This ensures the preprocessor properly skips the entire DNS resolver code block that uses unavailable iOS APIs.

The patches now have correct unified diff format that should apply cleanly.